### PR TITLE
Add alternative mastercodes to both Xenosaga Episode 2 (NTSC-U) discs

### DIFF
--- a/CHT/SLUS_208.92.cht
+++ b/CHT/SLUS_208.92.cht
@@ -3,6 +3,7 @@
 
 Mastercode
 90122b38 0c048a76
+// 901947d0 0c0a9b54 // ALTERNATIVE MASTERCODE
 
 //Widescreen hack by nemesis2000
 //wide 

--- a/CHT/SLUS_211.33.cht
+++ b/CHT/SLUS_211.33.cht
@@ -3,6 +3,7 @@
 
 Mastercode
 90122b38 0c048a76
+// 901947d0 0c0a9b54 // ALTERNATIVE MASTERCODE
 
 //Widescreen hack by nemesis2000
 //wide 


### PR DESCRIPTION
OPL failed to load the cheat file for my copy without these codes, so I figured I should tack them on in-case others have this issue.